### PR TITLE
Fix copyright symbol in _libusb.py

### DIFF
--- a/src/libusb/_libusb.py
+++ b/src/libusb/_libusb.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2007-2008 Daniel Drake <dsd@gentoo.org>
 # Copyright (c) 2012 Pete Batard <pete@akeo.ie>
 # Copyright (c) 2012-2018 Nathan Hjelm <hjelmn@cs.unm.edu>
-# Copyright (©) 2014-2020 Chris Dickens <christopher.a.dickens@gmail.com>
+# Copyright (c) 2014-2020 Chris Dickens <christopher.a.dickens@gmail.com>
 # For more information, please visit: http://libusb.info
 #
 # This library is free software; you can redistribute it and/or


### PR DESCRIPTION
A copyright symbol in _libusb.py was encoded as ISO-8859-1 (hexadecimal A9). In Python 3, source files should be encoded as UTF-8 by default (see [PEP3120](https://peps.python.org/pep-3120/)). This commit fixes the file by simply using `(c)` as the copyright symbol.